### PR TITLE
Resolve acl argument deprecation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,10 @@ resource "aws_route53_zone" "mer-vg" {
 
 resource "aws_s3_bucket" "x-mer-vg" {
   bucket = "x-mer-vg"
+}
+
+resource "aws_s3_bucket_acl" "x-mer-vg" {
+  bucket = aws_s3_bucket.x-mer-vg.id
   acl    = "public-read"
 }
 
@@ -55,6 +59,10 @@ POLICY
 
 resource "aws_s3_bucket" "x-mer-vg-logs" {
   bucket = "x-mer-vg-logs"
+}
+
+resource "aws_s3_bucket_acl" "x-mer-vg-logs" {
+  bucket = aws_s3_bucket.x-mer-vg-logs.id
   acl    = "private"
 }
 


### PR DESCRIPTION
Resolves the following warning:
```
╷
│ Warning: Argument is deprecated
│ 
│   with aws_s3_bucket.x-mer-vg,
│   on main.tf line 31, in resource "aws_s3_bucket" "x-mer-vg":
│   31:   acl    = "public-read"
│ 
│ Use the aws_s3_bucket_acl resource instead
│ 
│ (and 3 more similar warnings elsewhere)
╵
```